### PR TITLE
feat: transit journal and live updates

### DIFF
--- a/app/src/api/supabase.tsx
+++ b/app/src/api/supabase.tsx
@@ -1,10 +1,6 @@
 import { supabase } from "@utils/supabase";
 import { newError } from "@utils/utils";
 
-// type APISuccess = { data: any[]; error: null };
-// type APIFailure = { data: null; error: APIError };
-// type APIResponse = Promise<APISuccess | APIFailure>;
-
 // Inserts data into a specified Supabase table.
 export async function insertData(table: string, payload: any[]): Promise<any[]> {
   const errMsg = `Failed to insert data into ${table}`;
@@ -18,18 +14,47 @@ export async function insertData(table: string, payload: any[]): Promise<any[]> 
   }
 }
 
+// Updates data in a specified Supabase table.
 export async function updateData(
-  table: string,
   payload: any,
-  column: string,
-  value: any,
+  table: string,
+  filters: Record<string, any>,
 ): Promise<any[]> {
   const errMsg = `Failed to update data in ${table}`;
   try {
-    const { data, error } = await supabase.from(table).update(payload).eq(column, value).select();
+    let query = supabase.from(table).update(payload);
+    if (filters) {
+      Object.entries(filters).forEach(([key, value]) => {
+        query = query.eq(key, value);
+      });
+    }
+    const { data, error } = await query.select();
     if (error) throw new Error(error.message);
     return data;
   } catch (error: Error | any) {
+    console.error("[API ERROR]", errMsg, error.message);
+    throw new Error(error.message || errMsg);
+  }
+}
+
+export async function fetchData(
+  table: string,
+  columns: string[] = ["*"],
+  filters: Record<string, any> = {},
+): Promise<any[]> {
+  const errMsg = `Failed to fetch data from ${table}`;
+  try {
+    let query = supabase.from(table).select(columns.join(", "));
+
+    for (const [key, value] of Object.entries(filters)) {
+      query = query.eq(key, value);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return data;
+  } catch (error: any) {
     console.error("[API ERROR]", errMsg, error.message);
     throw new Error(error.message || errMsg);
   }

--- a/app/src/app/(search)/3-trip-overview.tsx
+++ b/app/src/app/(search)/3-trip-overview.tsx
@@ -55,8 +55,9 @@ export default function TripOverview() {
 
       // bind transit journal to user
       await updateProfile({ id: user!.id, transitJournalId });
-      Alert.alert("Trip started successfully");
-      // router.push("/(journal)/transit-journal");
+      // FIXME: wait for 5 seconds to simulate trip start
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+      router.push("/(journal)/transit-journal");
     } catch (error) {
       Alert.alert("Error starting trip");
       console.error(error);

--- a/app/src/app/(search)/3-trip-overview.tsx
+++ b/app/src/app/(search)/3-trip-overview.tsx
@@ -55,8 +55,8 @@ export default function TripOverview() {
 
       // bind transit journal to user
       await updateProfile({ id: user!.id, transitJournalId });
-      // FIXME: wait for 5 seconds to simulate trip start
-      await new Promise((resolve) => setTimeout(resolve, 5000));
+      // FIXME: should verify if journal context is updated before navigating
+      await new Promise((resolve) => setTimeout(resolve, 3000));
       router.push("/(journal)/transit-journal");
     } catch (error) {
       Alert.alert("Error starting trip");

--- a/app/src/app/(tabs)/index.tsx
+++ b/app/src/app/(tabs)/index.tsx
@@ -1,21 +1,45 @@
-import React from "react";
-import { Text, Image, View, SafeAreaView, Pressable } from "react-native";
-import Mapbox, { MapView, Camera, LocationPuck } from "@rnmapbox/maps";
-import { MAPBOX_ACCESS_TOKEN } from "../../utils/mapbox-config";
-
 import { useRouter } from "expo-router";
+import * as ExpoLocation from "expo-location";
+import React, { useEffect, useState } from "react";
+import Mapbox, { MapView, Camera, LocationPuck, Images as MapImage } from "@rnmapbox/maps";
+import { Text, Image, View, SafeAreaView, Pressable } from "react-native";
 
-import RecentTrips from "@components/search/RecentTrips";
+import trafficIcon from "@assets/report-traffic.png";
+import lineIcon from "@assets/report-lines.png";
+import disruptionIcon from "@assets/report-disruption.png";
+
+import LiveUpdateMarker from "@components/map/LiveUpdateMarker";
 import Header from "@components/ui/Header";
+import RecentTrips from "@components/search/RecentTrips";
+import { fetchNearbyLiveUpdates } from "@services/trip-service-v2";
 
+import { MAPBOX_ACCESS_TOKEN } from "../../utils/mapbox-config";
 Mapbox.setAccessToken(MAPBOX_ACCESS_TOKEN);
 
 export default function Index() {
   const router = useRouter();
+  const [liveUpdates, setLiveUpdates] = useState<LiveUpdate[]>([]);
 
   const handleTextInputFocus = () => {
     router.push("/(search)/1-search-trip");
   };
+
+  useEffect(() => {
+    // TODO: make this to an onChangeListener
+    const fetchLiveUpdates = async () => {
+      const location = await ExpoLocation.getCurrentPositionAsync({});
+      const coordinates: Coordinates = [location.coords.longitude, location.coords.latitude];
+      try {
+        // Fetch live updates within 10km radius
+        const data = await fetchNearbyLiveUpdates(coordinates, 10000);
+        setLiveUpdates(data);
+      } catch (error) {
+        console.error("Error fetching live updates", error);
+      }
+    };
+
+    fetchLiveUpdates();
+  }, []);
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
@@ -30,12 +54,24 @@ export default function Index() {
             style={{ width: 15, height: 15, marginRight: 10 }}
             resizeMode="contain"
           />
+
           <Text style={{ fontSize: 12, color: "#888" }}>Where are we off to today?</Text>
         </Pressable>
       </View>
       <MapView style={{ flex: 1 }} styleURL="mapbox://styles/mapbox/streets-v12">
         <Camera followZoomLevel={12} followUserLocation />
         <LocationPuck />
+        {liveUpdates.map((update) => (
+          <LiveUpdateMarker
+            key={update.id}
+            id={update.id}
+            type={update.type}
+            coordinates={update.coordinate}
+          />
+        ))}
+        <MapImage
+          images={{ Traffic: trafficIcon, Disruption: disruptionIcon, "Long Line": lineIcon }}
+        />
       </MapView>
       <RecentTrips />
     </SafeAreaView>

--- a/app/src/components/journal/ReportTab.tsx
+++ b/app/src/components/journal/ReportTab.tsx
@@ -1,7 +1,9 @@
-import React, { useState } from "react";
-import { Text, View, Image, TouchableOpacity } from "react-native";
-
+import React from "react";
+import * as ExpoLocation from "expo-location";
+import { Text, View, Image, TouchableOpacity, Alert } from "react-native";
 import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
+
+import { useTransitJournal } from "@contexts/TransitJournal";
 
 const reportOptions = [
   { label: "Traffic", image: require("@assets/report-traffic.png") },
@@ -11,10 +13,20 @@ const reportOptions = [
 
 export default function ReportTab() {
   const snapPoints = ["15%", "20%", "40%", "72%"];
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
 
-  const toggleSelection = (label: string) => {
-    setSelectedOptions((prev) => (prev.includes(label) ? prev.filter((item) => item !== label) : [...prev, label]));
+  const { addLiveStatus } = useTransitJournal();
+
+  const handleReportPress = async (type: string) => {
+    const location = await ExpoLocation.getCurrentPositionAsync({});
+    const coordinate: Coordinates = [location.coords.longitude, location.coords.latitude];
+
+    Alert.alert("Send Live Update", `Report ${type} at your current location?`, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Send Live Update",
+        onPress: () => addLiveStatus({ type, coordinate }),
+      },
+    ]);
   };
 
   return (
@@ -25,22 +37,20 @@ export default function ReportTab() {
         </View>
         <View className="flex flex-row justify-between px-12">
           {reportOptions.map(({ label, image }) => {
-            const isSelected = selectedOptions.includes(label);
             return (
               <TouchableOpacity
                 key={label}
-                onPress={() => toggleSelection(label)}
-                className={`border rounded py-5 w-24 items-center ${
-                  isSelected ? "border-primary bg-primary/10" : "border-gray-200"
+                onPress={() => handleReportPress(label)}
+                className={`border rounded py-5 w-24 items-center border-gray-200"
                 }`}
               >
                 <Image
                   source={image}
                   className="w-7 h-7 mb-2"
                   resizeMode="contain"
-                  style={{ tintColor: isSelected ? "#6D28D9" : "#9CA3AF" }} // Purple when selected, gray when not
+                  style={{ tintColor: "#9CA3AF" }} // Purple when selected, gray when not
                 />
-                <Text className={`${isSelected ? "text-primary" : "text-secondary"} text-sm`}>{label}</Text>
+                <Text className={`text-secondary text-sm`}>{label}</Text>
               </TouchableOpacity>
             );
           })}

--- a/app/src/components/journal/ReportTab.tsx
+++ b/app/src/components/journal/ReportTab.tsx
@@ -14,7 +14,7 @@ const reportOptions = [
 export default function ReportTab() {
   const snapPoints = ["15%", "20%", "40%", "72%"];
 
-  const { addLiveStatus } = useTransitJournal();
+  const { addLiveUpdate } = useTransitJournal();
 
   const handleReportPress = async (type: string) => {
     const location = await ExpoLocation.getCurrentPositionAsync({});
@@ -24,7 +24,7 @@ export default function ReportTab() {
       { text: "Cancel", style: "cancel" },
       {
         text: "Send Live Update",
-        onPress: () => addLiveStatus({ type, coordinate }),
+        onPress: () => addLiveUpdate({ type, coordinate }),
       },
     ]);
   };

--- a/app/src/components/map/LiveUpdateMarker.tsx
+++ b/app/src/components/map/LiveUpdateMarker.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { point } from "@turf/helpers";
+import { ShapeSource, SymbolLayer, Images } from "@rnmapbox/maps";
+
+interface LiveUpdateMarkerProps {
+  id: string;
+  type: string;
+  coordinates: Coordinates | null | undefined;
+  iconSize?: number;
+}
+function LiveUpdateMarker({ id, type, coordinates, iconSize = 0.03 }: LiveUpdateMarkerProps) {
+  if (!coordinates) return null;
+
+  return (
+    <ShapeSource id={id} shape={point(coordinates)}>
+      <SymbolLayer
+        id={`${id}-icon`}
+        style={{
+          iconImage: type,
+          iconSize: iconSize,
+        }}
+      />
+    </ShapeSource>
+  );
+}
+export default LiveUpdateMarker;

--- a/app/src/components/search/RecentTrips.tsx
+++ b/app/src/components/search/RecentTrips.tsx
@@ -1,15 +1,24 @@
 import React from "react";
-import { Text } from "react-native";
-
+import { Text, Pressable } from "react-native";
 import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
+import { useRouter } from "expo-router";
+
+import { useTransitJournal } from "@contexts/TransitJournal";
 
 export default function RecentTrips() {
   const snapPoints = ["20%"];
+  const { hasActiveTransitJournal } = useTransitJournal();
+  const router = useRouter();
 
   return (
     <BottomSheet snapPoints={snapPoints} index={1}>
       <BottomSheetView className="flex flex-col px-5 gap-2">
         <Text className="text-xl font-bold">Recent Trips</Text>
+        {hasActiveTransitJournal && (
+          <Pressable onPress={() => router.push("/(journal)/transit-journal")}>
+            <Text className="text-blue-500 underline">Active Transit Journal</Text>
+          </Pressable>
+        )}
       </BottomSheetView>
     </BottomSheet>
   );

--- a/app/src/contexts/TransitJournal/index.tsx
+++ b/app/src/contexts/TransitJournal/index.tsx
@@ -6,6 +6,7 @@ import {
   fetchTransitJournal,
   fetchTrip,
   fetchSegments,
+  insertLiveStatus,
 } from "@services/trip-service-v2";
 
 interface TransitJournalContextType {
@@ -14,6 +15,7 @@ interface TransitJournalContextType {
   trip: Trip | null;
   segments: Segment[] | null;
   loading: boolean;
+  addLiveStatus: (status: { type: string; coordinate: Coordinates }) => Promise<void>;
 }
 
 const TransitJournalContext = createContext<TransitJournalContextType | null>(null);
@@ -97,12 +99,28 @@ export function TransitJournalProvider({ children }: { children: ReactNode }) {
     setLoading(false);
   }, [transitJournalId]);
 
+  const addLiveStatus = async (status: { type: string; coordinate: Coordinates }) => {
+    const payload: CreateLiveStatus = {
+      contributorId: user.id,
+      TransitJournalId: transitJournalId!,
+      type: status.type,
+      coordinate: status.coordinate,
+    };
+
+    try {
+      await insertLiveStatus(payload);
+    } catch (error) {
+      throw new Error("Error adding live status");
+    }
+  };
+
   const value = {
     hasActiveTransitJournal,
     transitJournalData,
     trip,
     segments,
     loading,
+    addLiveStatus,
   };
   return <TransitJournalContext.Provider value={value}>{children}</TransitJournalContext.Provider>;
 }

--- a/app/src/contexts/TransitJournal/index.tsx
+++ b/app/src/contexts/TransitJournal/index.tsx
@@ -6,7 +6,7 @@ import {
   fetchTransitJournal,
   fetchTrip,
   fetchSegments,
-  insertLiveStatus,
+  insertLiveUpdate,
 } from "@services/trip-service-v2";
 
 interface TransitJournalContextType {
@@ -15,7 +15,7 @@ interface TransitJournalContextType {
   trip: Trip | null;
   segments: Segment[] | null;
   loading: boolean;
-  addLiveStatus: (status: { type: string; coordinate: Coordinates }) => Promise<void>;
+  addLiveUpdate: (status: { type: LiveUpdateType; coordinate: Coordinates }) => Promise<void>;
 }
 
 const TransitJournalContext = createContext<TransitJournalContextType | null>(null);
@@ -99,16 +99,16 @@ export function TransitJournalProvider({ children }: { children: ReactNode }) {
     setLoading(false);
   }, [transitJournalId]);
 
-  const addLiveStatus = async (status: { type: string; coordinate: Coordinates }) => {
-    const payload: CreateLiveStatus = {
+  const addLiveUpdate = async (status: { type: LiveUpdateType; coordinate: Coordinates }) => {
+    const payload: CreateLiveUpdate = {
       contributorId: user.id,
-      TransitJournalId: transitJournalId!,
+      transitJournalId: transitJournalId!,
       type: status.type,
       coordinate: status.coordinate,
     };
 
     try {
-      await insertLiveStatus(payload);
+      await insertLiveUpdate(payload);
     } catch (error) {
       throw new Error("Error adding live status");
     }
@@ -120,7 +120,7 @@ export function TransitJournalProvider({ children }: { children: ReactNode }) {
     trip,
     segments,
     loading,
-    addLiveStatus,
+    addLiveUpdate,
   };
   return <TransitJournalContext.Provider value={value}>{children}</TransitJournalContext.Provider>;
 }

--- a/app/src/contexts/TripSearch/index.tsx
+++ b/app/src/contexts/TripSearch/index.tsx
@@ -46,7 +46,7 @@ export function TripSearchProvider({ children }: { children: ReactNode }) {
       const existingTrips = await fetchTripData(trip, 1500);
       const fullTrips = await appendWalkingSegments(user.id, existingTrips, trip);
       setSuggestedTrips(fullTrips);
-      applyFilters(filters);
+      setFilteredTrips(fullTrips);
     } catch (error) {
       console.error("Failed to fetch trips:", error);
     }

--- a/app/src/services/trip-service-v2.ts
+++ b/app/src/services/trip-service-v2.ts
@@ -1,7 +1,11 @@
-import { FullTripsSchema } from "types/schema";
-import { TransitJournalSchema, FullTripSchema, SegmentsSchema } from "types/schema";
-
 import { insertData, updateData, fetchData, fetchDataRPC } from "@api/supabase";
+import {
+  TransitJournalSchema,
+  FullTripsSchema,
+  FullTripSchema,
+  SegmentsSchema,
+  LiveUpdatesSchema,
+} from "types/schema";
 import {
   convertKeysToSnakeCase,
   convertKeysToCamelCase,
@@ -15,8 +19,6 @@ export async function insertTrip(trip: CreateTrip): Promise<string> {
     const payload = convertKeysToSnakeCase(trip);
     payload.start_coords = convertToPointWKT(payload.start_coords);
     payload.end_coords = convertToPointWKT(payload.end_coords);
-
-    // Insert the trip data into the database
     const res = await insertData("trips_v2", [payload]);
     return res[0].id;
   } catch (error) {
@@ -34,8 +36,6 @@ export async function insertSegments(segments: CreateSegment[]): Promise<string[
       end_coords: convertToPointWKT(segment.end_coords),
       waypoints: convertToMultiPointWKT(segment.waypoints),
     }));
-
-    // Insert the segment data into the database
     const res = await insertData("segments_v2", payload);
     return res.map(({ id }) => id);
   } catch (error) {
@@ -54,8 +54,6 @@ export async function insertTripSegmentLinks(
       segment_id: segmentId,
       segment_order: segmentOrder,
     }));
-
-    // Insert the trip-segment links into the database
     const res = await insertData("trip_segment_links_v2", payload);
     return res.map(({ id }) => id);
   } catch (error: Error | any) {
@@ -63,12 +61,11 @@ export async function insertTripSegmentLinks(
   }
 }
 
-export async function insertLiveStatus(status: CreateLiveStatus): Promise<string> {
+// Inserts a new profile record into the database
+export async function insertLiveUpdate(status: CreateLiveUpdate): Promise<string> {
   try {
     const payload = convertKeysToSnakeCase(status);
     payload.coordinate = convertToPointWKT(payload.coordinate);
-
-    console.log("Inserting live status", payload);
     const res = await insertData("live_status_v2", [payload]);
     return res[0].id;
   } catch (error) {
@@ -80,7 +77,6 @@ export async function insertLiveStatus(status: CreateLiveStatus): Promise<string
 export async function insertTransitJournal(journal: CreateTransitJournal): Promise<string> {
   try {
     const payload = convertKeysToSnakeCase(journal);
-    // Insert the transit journal data into the database
     const res = await insertData("transit_journals_v2", [payload]);
     return res[0].id;
   } catch (error) {
@@ -91,7 +87,6 @@ export async function insertTransitJournal(journal: CreateTransitJournal): Promi
 // Fetches the transit journal ID for a user
 export async function fetchUserTransitJournal(userId: string): Promise<string | null> {
   try {
-    // Fetch the transit journal ID from the database
     const [data, ...rest] = await fetchData("profiles", ["transit_journal_id"], { id: userId });
     if (rest.length > 0) throw new Error("Multiple profiles found");
     return data.transit_journal_id;
@@ -103,7 +98,6 @@ export async function fetchUserTransitJournal(userId: string): Promise<string | 
 // Fetches the transit journal data for a given journal ID
 export async function fetchTransitJournal(journalId: string): Promise<TransitJournal> {
   try {
-    // Fetch the transit journal data from the database
     const [data, ...rest] = await fetchData("transit_journals_v2", ["*"], { id: journalId });
     if (rest.length > 0) throw new Error("Multiple transit journals found");
 
@@ -119,20 +113,18 @@ export async function fetchTransitJournal(journalId: string): Promise<TransitJou
 
 export async function fetchSegments(segmentIds: string[]): Promise<Segment[]> {
   try {
-    // Fetch the segment data from the database
     const segments = Promise.all(
       segmentIds.map(async (segmentId) => {
-        console.log("Fetching segment", segmentId);
         const data = await fetchDataRPC("fetch_segment", { segment_id: segmentId });
         return data;
       }),
     );
 
+    // Validate the response data
     const result = SegmentsSchema.safeParse(segments);
     if (!result.success) throw new Error("Invalid Segment Data");
     return result.data;
   } catch (error) {
-    console.log(error);
     throw new Error("Error fetching segments");
   }
 }
@@ -140,13 +132,11 @@ export async function fetchSegments(segmentIds: string[]): Promise<Segment[]> {
 // Fetches the trip data for a given trip ID
 export async function fetchTrip(tripId: string): Promise<FullTrip> {
   try {
-    // Fetch trip data from the database
     const [data, ...rest] = await fetchDataRPC("fetch_trip", { trip_id: tripId });
     if (rest.length > 0) throw new Error("Multiple trips found");
 
     // Validate the response data
-    const formattedData = convertKeysToCamelCase(data);
-    const result = FullTripSchema.safeParse(formattedData);
+    const result = FullTripSchema.safeParse(data);
     if (!result.success) throw new Error("Invalid Trip Data");
     return result.data;
   } catch (error) {
@@ -157,25 +147,38 @@ export async function fetchTrip(tripId: string): Promise<FullTrip> {
 // Fetches trip data based on provided details and radius
 export async function fetchTripData(endpoints: TripEndpoints, radius: number): Promise<FullTrip[]> {
   try {
-    const args = {
+    const res = await fetchDataRPC("fetch_nearby_trips", {
       start_lat: endpoints.startCoords[1],
       start_lon: endpoints.startCoords[0],
       end_lat: endpoints.endCoords[1],
       end_lon: endpoints.endCoords[0],
       radius,
-    };
-
-    // Fetch nearby trips from the database
-    const res = await fetchDataRPC("fetch_nearby_trips", args);
-    const formattedData = res.map(convertKeysToCamelCase);
+    });
 
     // Validate the response data
-    const result = FullTripsSchema.safeParse(formattedData);
+    const result = FullTripsSchema.safeParse(res);
     if (!result.success) throw new Error("Invalid Trip Data");
-
     return result.data;
   } catch (error) {
     throw new Error("Error fetching trip data");
+  }
+}
+
+// Fetches nearby live updates based on provided coordinates and radius
+export async function fetchNearbyLiveUpdates(
+  coordinates: Coordinates,
+  radius: number,
+): Promise<LiveUpdate[]> {
+  try {
+    const args = { lat: coordinates[1], lon: coordinates[0], radius };
+    const res = await fetchDataRPC("fetch_nearby_live_updates", args);
+
+    // Validate the response data
+    const result = LiveUpdatesSchema.safeParse(res);
+    if (!result.success) throw new Error("Invalid Live Update Data");
+    return result.data;
+  } catch (error) {
+    throw new Error("Error fetching live updates");
   }
 }
 
@@ -183,7 +186,6 @@ export async function fetchTripData(endpoints: TripEndpoints, radius: number): P
 export async function updateProfile(profile: Partial<Profile>): Promise<void> {
   try {
     const payload = convertKeysToSnakeCase(profile);
-    // Update the profile data in the database
     await updateData(payload, "profiles", { id: profile.id });
   } catch (error) {
     throw new Error("Error updating profile");

--- a/app/src/services/trip-service-v2.ts
+++ b/app/src/services/trip-service-v2.ts
@@ -63,6 +63,19 @@ export async function insertTripSegmentLinks(
   }
 }
 
+export async function insertLiveStatus(status: CreateLiveStatus): Promise<string> {
+  try {
+    const payload = convertKeysToSnakeCase(status);
+    payload.coordinate = convertToPointWKT(payload.coordinate);
+
+    console.log("Inserting live status", payload);
+    const res = await insertData("live_status_v2", [payload]);
+    return res[0].id;
+  } catch (error) {
+    throw new Error("Error inserting live status");
+  }
+}
+
 // Inserts a new transit journal record into the database
 export async function insertTransitJournal(journal: CreateTransitJournal): Promise<string> {
   try {

--- a/app/src/services/trip-service-v2.ts
+++ b/app/src/services/trip-service-v2.ts
@@ -1,5 +1,5 @@
 import { FullTripsSchema } from "types/schema";
-import { TransitJournalSchema, FullTripSchema } from "types/schema";
+import { TransitJournalSchema, FullTripSchema, SegmentsSchema } from "types/schema";
 
 import { insertData, updateData, fetchData, fetchDataRPC } from "@api/supabase";
 import {
@@ -97,11 +97,30 @@ export async function fetchTransitJournal(journalId: string): Promise<TransitJou
     // Validate the response data
     const formattedData = convertKeysToCamelCase(data);
     const result = TransitJournalSchema.safeParse(formattedData);
-    console.log("Transit Journal Data!", result);
     if (!result.success) throw new Error("Invalid Transit Journal Data");
     return result.data;
   } catch (error) {
     throw new Error("Error fetching transit journal");
+  }
+}
+
+export async function fetchSegments(segmentIds: string[]): Promise<Segment[]> {
+  try {
+    // Fetch the segment data from the database
+    const segments = Promise.all(
+      segmentIds.map(async (segmentId) => {
+        console.log("Fetching segment", segmentId);
+        const data = await fetchDataRPC("fetch_segment", { segment_id: segmentId });
+        return data;
+      }),
+    );
+
+    const result = SegmentsSchema.safeParse(segments);
+    if (!result.success) throw new Error("Invalid Segment Data");
+    return result.data;
+  } catch (error) {
+    console.log(error);
+    throw new Error("Error fetching segments");
   }
 }
 

--- a/app/src/types/location-types.d.ts
+++ b/app/src/types/location-types.d.ts
@@ -9,8 +9,6 @@ declare global {
     };
   }
 
-  export type Coordinates = [number, number];
-
   export interface MapboxDirectionsResponse {
     routes: MapboxRoute[];
     waypoints: MapboxWaypoint[];

--- a/app/src/types/route-types.d.ts
+++ b/app/src/types/route-types.d.ts
@@ -6,7 +6,6 @@ import type {
   TransportationModeSchema,
   TransitJournalStatusSchema,
   CoordinatesSchema,
-  LiveStatusSchema,
   NavigationStepsSchema,
   TripEndpointsSchema,
   TripSchema,
@@ -15,6 +14,7 @@ import type {
   TripSearchSchema,
   TripSegmentLinkSchema,
   TransitJournalSchema,
+  LiveStatusSchema,
   ProfileSchema,
 } from "./schema";
 
@@ -50,7 +50,6 @@ declare global {
   export type TransitJournalStatus = z.infer<typeof TransitJournalStatusSchema>;
 
   export type Coordinates = z.infer<typeof CoordinatesSchema>;
-  export type LiveStatus = z.infer<typeof LiveStatusSchema>;
   export type NavigationSteps = z.infer<typeof NavigationStepsSchema>;
 
   export type TripEndpoints = z.infer<typeof TripEndpointsSchema>;
@@ -72,6 +71,12 @@ declare global {
   export type CreateTransitJournal = Omit<
     TransitJournal,
     "id" | "createdAt" | "updatedAt" | "startTime" | "endTime" | "status"
+  >;
+
+  export type LiveStatus = z.infer<typeof LiveStatusSchema>;
+  export type CreateLiveStatus = Omit<
+    LiveStatus,
+    "id" | "createdAt" | "updatedAt" | "expirationDate"
   >;
 
   export type Profile = z.infer<typeof ProfileSchema>;

--- a/app/src/types/route-types.d.ts
+++ b/app/src/types/route-types.d.ts
@@ -5,6 +5,7 @@ import { Timestamp } from "react-native-reanimated/lib/typescript/commonTypes";
 import type {
   TransportationModeSchema,
   TransitJournalStatusSchema,
+  LiveUpdateTypeSchema,
   CoordinatesSchema,
   NavigationStepsSchema,
   TripEndpointsSchema,
@@ -14,7 +15,7 @@ import type {
   TripSearchSchema,
   TripSegmentLinkSchema,
   TransitJournalSchema,
-  LiveStatusSchema,
+  LiveUpdateSchema,
   ProfileSchema,
 } from "./schema";
 
@@ -48,6 +49,7 @@ declare global {
 
   export type TransportationMode = z.infer<typeof TransportationModeSchema>;
   export type TransitJournalStatus = z.infer<typeof TransitJournalStatusSchema>;
+  export type LiveUpdateType = z.infer<typeof LiveUpdateTypeSchema>;
 
   export type Coordinates = z.infer<typeof CoordinatesSchema>;
   export type NavigationSteps = z.infer<typeof NavigationStepsSchema>;
@@ -73,9 +75,9 @@ declare global {
     "id" | "createdAt" | "updatedAt" | "startTime" | "endTime" | "status"
   >;
 
-  export type LiveStatus = z.infer<typeof LiveStatusSchema>;
-  export type CreateLiveStatus = Omit<
-    LiveStatus,
+  export type LiveUpdate = z.infer<typeof LiveUpdateSchema>;
+  export type CreateLiveUpdate = Omit<
+    LiveUpdate,
     "id" | "createdAt" | "updatedAt" | "expirationDate"
   >;
 

--- a/app/src/types/schema.ts
+++ b/app/src/types/schema.ts
@@ -46,8 +46,6 @@ export const TransitJournalStatusSchema = z.enum(["success", "cancelled", "ongoi
 
 export const CoordinatesSchema = z.tuple([z.number(), z.number()]);
 
-export const LiveStatusSchema = z.object({ type: z.string(), coordinates: CoordinatesSchema });
-
 export const NavigationStepsSchema = z.object({
   instruction: z.string(),
   location: CoordinatesSchema,
@@ -93,7 +91,6 @@ export const SegmentSchema = z.object({
   duration: z.number(),
   distance: z.number(),
   cost: z.number(),
-  liveStatus: z.array(LiveStatusSchema),
   waypoints: z.array(CoordinatesSchema),
   navigationSteps: z.array(NavigationStepsSchema),
   startLocation: z.string(),
@@ -148,6 +145,17 @@ export const TransitJournalSchema = z.object({
   startTime: z.string(),
   endTime: z.string().nullable(),
   status: TransitJournalStatusSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export const LiveStatusSchema = z.object({
+  id: z.string(),
+  contributorId: z.string(),
+  TransitJournalId: z.string(),
+  type: z.string(),
+  coordinate: CoordinatesSchema,
+  expirationDate: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });

--- a/app/src/types/schema.ts
+++ b/app/src/types/schema.ts
@@ -42,7 +42,7 @@ export type GtfsRoute = z.infer<typeof GtfsRoute>;
 
 export const TransportationModeSchema = z.enum(["Train", "Bus", "Jeep", "UV", "Tricycle", "Walk"]);
 
-export const TransitJournalStatusSchema = z.enum(["Success", "Cancelled", "Ongoing"]);
+export const TransitJournalStatusSchema = z.enum(["success", "cancelled", "ongoing"]);
 
 export const CoordinatesSchema = z.tuple([z.number(), z.number()]);
 

--- a/app/src/types/schema.ts
+++ b/app/src/types/schema.ts
@@ -44,6 +44,8 @@ export const TransportationModeSchema = z.enum(["Train", "Bus", "Jeep", "UV", "T
 
 export const TransitJournalStatusSchema = z.enum(["success", "cancelled", "ongoing"]);
 
+export const LiveUpdateTypeSchema = z.enum(["Traffic", "Disruption", "Long Line"]);
+
 export const CoordinatesSchema = z.tuple([z.number(), z.number()]);
 
 export const NavigationStepsSchema = z.object({
@@ -149,16 +151,18 @@ export const TransitJournalSchema = z.object({
   updatedAt: z.string(),
 });
 
-export const LiveStatusSchema = z.object({
+export const LiveUpdateSchema = z.object({
   id: z.string(),
   contributorId: z.string(),
-  TransitJournalId: z.string(),
-  type: z.string(),
+  transitJournalId: z.string(),
+  type: LiveUpdateTypeSchema,
   coordinate: CoordinatesSchema,
   expirationDate: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
+
+export const LiveUpdatesSchema = z.array(LiveUpdateSchema);
 
 export const ProfileSchema = z.object({
   id: z.string(),


### PR DESCRIPTION
Merge #34 before this.

This PR connects the transit journal database to the transit journal page and introduces basic live update rendering.

### App Changes
- Integrated the transit journal database into the transit journal page.
- Added a redirect link from the home page to an ongoing transit journal.
- Implemented live update submission within the transit journal.
- Displayed live updates on the home page.

### Supabase Changes
- Removed live updates from the `segments` table.
- Introduced a new `live_updates` table.
- Renamed all references from `live_status` to `live_updates`.
- Added PostgreSQL functions:
  - `fetch_trip`
  - `fetch_segment`
  - `fetch_nearby_live_updates`
  - [Supabase SQL Link](https://supabase.com/dashboard/project/bspdqbaestgrqeanapux/sql/d2e7eff6-cfa1-4391-8725-7ff427296783)

> [!WARNING]
> These database changes will break older versions of the app.

---

### Future Work
- Render live updates within the transit journal page and use PostGIS to query nearby coordinates along a given route.
- Add live update icons for better visualization.
- Implement automatic cleanup of expired live updates.
- Implement cleanup of transit journal data upon completion.
- Set up a PostgreSQL `onchange` listener for real-time live update tracking.