### PR TITLE
feat: live updates

### DIFF
--- a/app/src/app/(contribute)/2-review-trip.tsx
+++ b/app/src/app/(contribute)/2-review-trip.tsx
@@ -17,11 +17,18 @@ import { useTripCreator } from "@contexts/TripCreator/TripCreatorContext";
 
 export default function TripReview() {
   const { cameraRef } = useMapView();
-  const { updateRoute, setInEditMode, deleteSegment } = useTripCreator();
-  const { clearTripData, clearRouteData, submitTrip } = useTripCreator();
-  const { trip, segments, isSegmentEmpty, isSegmentComplete } = useTripCreator();
-
-  const segmentCoordinates = segments.map(({ waypoints }) => waypoints);
+  const {
+    trip,
+    segments,
+    isSegmentEmpty,
+    isSegmentComplete,
+    updateRoute,
+    setEditingIndex,
+    deleteSegment,
+    clearTripData,
+    clearRouteData,
+    submitTrip,
+  } = useTripCreator();
 
   const handleCreateSegment = () => {
     clearRouteData();
@@ -29,12 +36,9 @@ export default function TripReview() {
   };
 
   const handleEditSegment = (index: number) => {
-    setInEditMode(true);
+    setEditingIndex(index);
     updateRoute(segments[index]);
-    router.replace({
-      pathname: "/(contribute)/4-edit-transfer",
-      params: { index },
-    });
+    router.replace("/(contribute)/4-edit-transfer");
   };
 
   const handleDeleteSegment = () => {
@@ -50,6 +54,7 @@ export default function TripReview() {
       Alert.alert("Trip Submitted");
       router.replace("/(tabs)");
     } catch (error) {
+      console.error(error);
       Alert.alert("Error submitting trip");
     }
   };
@@ -87,7 +92,7 @@ export default function TripReview() {
       </View>
 
       <MapShell cameraRef={cameraRef} fitBounds={[trip.startCoords, trip.endCoords]}>
-        <DirectionLines coordinates={segmentCoordinates} />
+        <DirectionLines coordinates={segments.map(({ waypoints }) => waypoints)} />
         <SymbolMarker id="start-loc" label={trip.startLocation} coordinates={trip.startCoords} />
         <SymbolMarker id="end-loc" label={trip.endLocation} coordinates={trip.endCoords} />
       </MapShell>

--- a/app/src/app/(journal)/transit-journal.tsx
+++ b/app/src/app/(journal)/transit-journal.tsx
@@ -1,15 +1,16 @@
 import { useRouter } from "expo-router";
-import * as ExpoLocation from "expo-location";
+import type { Location } from "@rnmapbox/maps";
 import { ShapeSource, LineLayer } from "@rnmapbox/maps";
 import React, { useEffect, useRef, useState } from "react";
-import Mapbox, { MapView, Camera, UserLocation, Location } from "@rnmapbox/maps";
-import { Alert, SafeAreaView, View, Text, Button, Pressable } from "react-native";
+import { SafeAreaView, View, Text, Button, Pressable } from "react-native";
 
 import Header from "@components/ui/Header";
+import { MapShell } from "@components/map/MapShell";
 import ReportTab from "@components/journal/ReportTab";
 import CircleMarker from "@components/map/CircleMarker";
 import TransferModal from "@components/journal/TransferModal";
 import CompleteModal from "@components/journal/CompleteModal";
+import JournalInstructions from "@components/journal/JournalInstructions";
 
 import {
   computeHeading,
@@ -17,15 +18,13 @@ import {
   getNearestSegment,
   getNearestStep,
 } from "@utils/map-utils";
+import { useMapView } from "@hooks/use-map-view";
 import { useTransitJournal } from "@contexts/TransitJournal";
 import { TRANSPORTATION_COLORS } from "@constants/transportation-color";
-import { MAPBOX_ACCESS_TOKEN } from "@utils/mapbox-config";
-
-Mapbox.setAccessToken(MAPBOX_ACCESS_TOKEN);
 
 export default function TransitJournal() {
+  const { userLocation, cameraRef } = useMapView();
   const router = useRouter();
-  const cameraRef = useRef<Camera>(null);
   const routeSourcesRef = useRef<{ [key: string]: ShapeSource | null }>({});
 
   const { hasActiveTransitJournal, segments } = useTransitJournal();
@@ -40,6 +39,7 @@ export default function TransitJournal() {
     router.push("/(journal)/journal-review");
   }
 
+  // TODO: move this!!!!
   const handleUserLocationUpdate = ({ coords }: Location) => {
     if (!segments) return;
     const tripSegments = JSON.parse(JSON.stringify(segments)) as Segment[];
@@ -106,24 +106,11 @@ export default function TransitJournal() {
     setCurrentStep(nextStep);
   };
 
-  // Request location permission and get initial app state
+  // Get initial app state
   useEffect(() => {
-    const getInitialLocation = async () => {
-      const { status } = await ExpoLocation.requestForegroundPermissionsAsync();
-
-      if (status !== "granted") {
-        Alert.alert(
-          "Location Access Needed",
-          "To use this feature, please enable location access in your settings.",
-          [{ text: "Cancel", style: "cancel" }],
-        );
-      } else {
-        const location = await ExpoLocation.getCurrentPositionAsync({});
-        handleUserLocationUpdate(location as Location);
-      }
-    };
-
-    getInitialLocation();
+    if (!userLocation) return;
+    const coords = { latitude: userLocation[1], longitude: userLocation[0] };
+    handleUserLocationUpdate({ coords });
   }, []);
 
   if (!hasActiveTransitJournal || !segments) {
@@ -139,16 +126,13 @@ export default function TransitJournal() {
     <SafeAreaView className="flex-1">
       <Header title="Transit Journal" />
       <View className="flex-1">
-        <MapView style={{ flex: 1 }} styleURL="mapbox://styles/mapbox/streets-v12">
-          <Camera ref={cameraRef} />
-
-          <UserLocation
-            visible={true}
-            showsUserHeadingIndicator={true}
-            onUpdate={handleUserLocationUpdate}
-            animated={false}
-          />
-
+        <MapShell
+          cameraRef={cameraRef}
+          handleUserLocation={handleUserLocationUpdate}
+          userLocationProps={{
+            animated: false,
+          }}
+        >
           {/* Render All Transfer Points */}
           {segments &&
             segments.map((segment, index) => (
@@ -177,22 +161,10 @@ export default function TransitJournal() {
                 />
               </ShapeSource>
             ))}
-        </MapView>
+        </MapShell>
 
         {/* Render Information section on top of screen */}
-        <View className="absolute top-0 w-full bg-white p-4">
-          {currentStep ? (
-            <Text className="font-bold text-lg mb-2">{currentStep.instruction}</Text>
-          ) : (
-            <Text className="font-bold text-lg mb-2">Follow the instructions on the map.</Text>
-          )}
-          {currentSegment?.landmark && (
-            <Text className="text-sm mb-2">Landmark: {currentSegment?.landmark}</Text>
-          )}
-          {currentSegment?.instruction && (
-            <Text className="text-sm mb-2">Instruction: {currentSegment?.instruction}</Text>
-          )}
-        </View>
+        <JournalInstructions currentStep={currentStep} currentSegment={currentSegment} />
 
         {/* Render Complete Button if near destination */}
         {showCompleteButton && (
@@ -205,6 +177,7 @@ export default function TransitJournal() {
         )}
       </View>
 
+      {/* Render Report Tab */}
       <ReportTab />
 
       <TransferModal

--- a/app/src/app/(journal)/transit-journal.tsx
+++ b/app/src/app/(journal)/transit-journal.tsx
@@ -21,8 +21,8 @@ import {
 } from "@utils/map-utils";
 import { useMapView } from "@hooks/use-map-view";
 import { useTransitJournal } from "@contexts/TransitJournal";
-import { fetchLiveUpdatesLine } from "@services/trip-service";
 import { TRANSPORTATION_COLORS } from "@constants/transportation-color";
+import { useLiveUpdates } from "@hooks/use-live-updates";
 
 // TODO: cleanup this file
 // TODO: cleanup this file
@@ -38,7 +38,8 @@ export default function TransitJournal() {
   const [showNextSegmentModal, setShowNextSegmentModal] = useState(false);
   const [showTripFinishedModal, setShowTripFinishedModal] = useState(false);
   const [showCompleteButton, setShowCompleteButton] = useState(false);
-  const [liveUpdates, setLiveUpdates] = useState<LiveUpdate[]>([]);
+
+  const { liveUpdates, setUpdateCoords } = useLiveUpdates("line", 30);
 
   function handleNavigateToReview() {
     setShowTripFinishedModal(false);
@@ -119,20 +120,10 @@ export default function TransitJournal() {
     handleUserLocationUpdate({ coords });
   }, []);
 
-  // Fetch live on segments every 30 seconds
-  // TODO: a lot of cleanup to do here
+  // Fetch live updates on segments
   useEffect(() => {
     if (!segments) return;
-    const line = segments.flatMap((segment) => segment.waypoints);
-    const fetchLiveUpdates = async () => {
-      const live = await fetchLiveUpdatesLine(line, 10);
-      setLiveUpdates(live);
-    };
-    fetchLiveUpdates();
-    const interval = setInterval(() => {
-      fetchLiveUpdates();
-    }, 30000);
-    return () => clearInterval(interval);
+    setUpdateCoords(segments.flatMap(({ waypoints }) => waypoints));
   }, [segments]);
 
   if (!hasActiveTransitJournal || !segments) {

--- a/app/src/app/(journal)/transit-journal.tsx
+++ b/app/src/app/(journal)/transit-journal.tsx
@@ -110,7 +110,14 @@ export default function TransitJournal() {
 
     // update the current segment and step information
     setCurrentSegment(segments[segmentIndex]);
-    setCurrentStep(nextStep);
+
+    // prevent unnecessary re-renders
+    if (
+      currentStep?.location[0] !== nextStep.location[0] ||
+      currentStep?.location[1] !== nextStep.location[1]
+    ) {
+      setCurrentStep(nextStep);
+    }
   };
 
   // Get initial app state

--- a/app/src/app/(tabs)/index.tsx
+++ b/app/src/app/(tabs)/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useRouter } from "expo-router";
 import { Text, Image, View, SafeAreaView, Pressable } from "react-native";
 
@@ -13,11 +12,14 @@ import { useLiveUpdates } from "@hooks/use-live-updates";
 export default function Index() {
   const router = useRouter();
   const { userLocation } = useMapView();
-  const [region, setRegion] = useState<any>(null);
-  const liveUpdates = useLiveUpdates(region, 30000);
+  const { liveUpdates, setUpdateCoords } = useLiveUpdates("box", 30);
 
   const handleTextInputFocus = () => {
     router.push("/(search)/1-search-trip");
+  };
+
+  const handleRegionChange = ({ properties }: MapViewRegionChange) => {
+    setUpdateCoords(properties.visibleBounds as Coordinates[]);
   };
 
   return (
@@ -36,7 +38,7 @@ export default function Index() {
           <Text style={{ fontSize: 12, color: "#888" }}>Where are we off to today?</Text>
         </Pressable>
       </View>
-      <MapShell center={userLocation} handleRegionChange={setRegion}>
+      <MapShell center={userLocation} handleRegionChange={handleRegionChange}>
         {liveUpdates.map((update) => (
           <LiveUpdateMarker
             key={update.id}

--- a/app/src/app/(tabs)/index.tsx
+++ b/app/src/app/(tabs)/index.tsx
@@ -1,45 +1,24 @@
+import { useState } from "react";
 import { useRouter } from "expo-router";
-import * as ExpoLocation from "expo-location";
-import React, { useEffect, useState } from "react";
-import Mapbox, { MapView, Camera, LocationPuck, Images as MapImage } from "@rnmapbox/maps";
 import { Text, Image, View, SafeAreaView, Pressable } from "react-native";
 
-import trafficIcon from "@assets/report-traffic.png";
-import lineIcon from "@assets/report-lines.png";
-import disruptionIcon from "@assets/report-disruption.png";
-
-import LiveUpdateMarker from "@components/map/LiveUpdateMarker";
 import Header from "@components/ui/Header";
+import { MapShell } from "@components/map/MapShell";
 import RecentTrips from "@components/search/RecentTrips";
-import { fetchNearbyLiveUpdates } from "@services/trip-service";
+import LiveUpdateMarker from "@components/map/LiveUpdateMarker";
 
-import { MAPBOX_ACCESS_TOKEN } from "../../utils/mapbox-config";
-Mapbox.setAccessToken(MAPBOX_ACCESS_TOKEN);
+import { useMapView } from "@hooks/use-map-view";
+import { useLiveUpdates } from "@hooks/use-live-updates";
 
 export default function Index() {
   const router = useRouter();
-  const [liveUpdates, setLiveUpdates] = useState<LiveUpdate[]>([]);
+  const { userLocation } = useMapView();
+  const [region, setRegion] = useState<any>(null);
+  const liveUpdates = useLiveUpdates(region, 30000);
 
   const handleTextInputFocus = () => {
     router.push("/(search)/1-search-trip");
   };
-
-  useEffect(() => {
-    // TODO: make this to an onChangeListener
-    const fetchLiveUpdates = async () => {
-      const location = await ExpoLocation.getCurrentPositionAsync({});
-      const coordinates: Coordinates = [location.coords.longitude, location.coords.latitude];
-      try {
-        // Fetch live updates within 10km radius
-        const data = await fetchNearbyLiveUpdates(coordinates, 10000);
-        setLiveUpdates(data);
-      } catch (error) {
-        console.error("Error fetching live updates", error);
-      }
-    };
-
-    fetchLiveUpdates();
-  }, []);
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
@@ -54,13 +33,10 @@ export default function Index() {
             style={{ width: 15, height: 15, marginRight: 10 }}
             resizeMode="contain"
           />
-
           <Text style={{ fontSize: 12, color: "#888" }}>Where are we off to today?</Text>
         </Pressable>
       </View>
-      <MapView style={{ flex: 1 }} styleURL="mapbox://styles/mapbox/streets-v12">
-        <Camera followZoomLevel={12} followUserLocation />
-        <LocationPuck />
+      <MapShell center={userLocation} handleRegionChange={setRegion}>
         {liveUpdates.map((update) => (
           <LiveUpdateMarker
             key={update.id}
@@ -69,10 +45,7 @@ export default function Index() {
             coordinates={update.coordinate}
           />
         ))}
-        <MapImage
-          images={{ Traffic: trafficIcon, Disruption: disruptionIcon, "Long Line": lineIcon }}
-        />
-      </MapView>
+      </MapShell>
       <RecentTrips />
     </SafeAreaView>
   );

--- a/app/src/components/contribute/JeepInformation.tsx
+++ b/app/src/components/contribute/JeepInformation.tsx
@@ -1,7 +1,7 @@
+import { Text } from "react-native";
 import React, { useState } from "react";
-import { View, Text } from "react-native";
-import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
 import { Picker } from "@react-native-picker/picker";
+import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
 
 export default function JeepInformation({
   dotcRoutes,
@@ -24,7 +24,9 @@ export default function JeepInformation({
     }
 
     // Find the selected route and update the state
-    const selected = dotcRoutes?.features.find((feature) => feature.properties.route_long_name === routeName);
+    const selected = dotcRoutes?.features.find(
+      (feature) => feature.properties.route_long_name === routeName,
+    );
     if (!selected) throw new Error(`Route ${routeName} not found`);
     setActiveRoute(selected);
     setSelectedRoute(routeName);
@@ -35,7 +37,11 @@ export default function JeepInformation({
       <BottomSheetView className="flex flex-col px-5 gap-2">
         <Text className="text-xl font-bold">More information</Text>
         {/* Dropdown select */}
-        <Picker selectedValue={selectedRoute} onValueChange={handleRouteChange} style={{ height: 50, width: "100%" }}>
+        <Picker
+          selectedValue={selectedRoute}
+          onValueChange={handleRouteChange}
+          style={{ height: 50, width: "100%" }}
+        >
           <Picker.Item label="All Routes" value={"All Routes"} />
           {uniqueRouteNames.map((routeName) => (
             <Picker.Item key={routeName} label={routeName} value={routeName} />

--- a/app/src/components/contribute/TransportModeInput.tsx
+++ b/app/src/components/contribute/TransportModeInput.tsx
@@ -2,16 +2,17 @@ import React, { useState } from "react";
 import { Text, View, TouchableOpacity, Image } from "react-native";
 import { TRANSPORTATION_MODES } from "@constants/transportation-modes";
 
-interface TransportationModeSelectionProps {
-  onTransportationModeChange: (mode: TransportationMode) => void;
+interface Props {
+  value: string;
+  onChange: (mode: TransportationMode) => void;
 }
 
-export default function TransportationModeSelection({ onTransportationModeChange }: TransportationModeSelectionProps) {
-  const [selectedMode, setSelectedMode] = useState<string>("");
+export default function TransportModeInput({ value, onChange }: Props) {
+  const [selectedMode, setSelectedMode] = useState<string>(value);
 
   const handleModeChange = (mode: TransportationMode) => {
     setSelectedMode(mode);
-    onTransportationModeChange(mode);
+    onChange(mode);
   };
 
   return (
@@ -34,7 +35,9 @@ export default function TransportationModeSelection({ onTransportationModeChange
                 tintColor: selectedMode === mode.label ? "#7F55D9" : "#7F7F7F",
               }}
             />
-            <Text className={`mt-1 text-xs ${selectedMode === mode.label ? "text-primary" : "text-secondary"}`}>
+            <Text
+              className={`mt-1 text-xs ${selectedMode === mode.label ? "text-primary" : "text-secondary"}`}
+            >
               {mode.label}
             </Text>
           </TouchableOpacity>

--- a/app/src/components/contribute/TripTitle.tsx
+++ b/app/src/components/contribute/TripTitle.tsx
@@ -7,7 +7,11 @@ interface TripTitleProps {
   transportationMode?: TransportationMode;
 }
 
-export default function TripTitle({ startLocation, endLocation, transportationMode }: TripTitleProps) {
+export default function TripTitle({
+  startLocation,
+  endLocation,
+  transportationMode,
+}: TripTitleProps) {
   const startLocationDisplay = startLocation.split(",")[0];
   const endLocationDisplay = endLocation.split(",")[0];
 

--- a/app/src/components/journal/JournalInstructions.tsx
+++ b/app/src/components/journal/JournalInstructions.tsx
@@ -1,0 +1,26 @@
+import { View, Text } from "react-native";
+
+interface Props {
+  currentStep: NavigationSteps | null;
+  currentSegment: Segment | null;
+}
+
+const JournalInstructions = ({ currentStep, currentSegment }: Props) => {
+  return (
+    <View className="absolute top-0 w-full bg-white p-4">
+      {currentStep ? (
+        <Text className="font-bold text-lg mb-2">{currentStep.instruction}</Text>
+      ) : (
+        <Text className="font-bold text-lg mb-2">Follow the instructions on the map.</Text>
+      )}
+      {currentSegment?.landmark && (
+        <Text className="text-sm mb-2">Landmark: {currentSegment?.landmark}</Text>
+      )}
+      {currentSegment?.instruction && (
+        <Text className="text-sm mb-2">Instruction: {currentSegment?.instruction}</Text>
+      )}
+    </View>
+  );
+};
+
+export default JournalInstructions;

--- a/app/src/components/map/DirectionLine.tsx
+++ b/app/src/components/map/DirectionLine.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { ShapeSource, LineLayer } from "@rnmapbox/maps";
+
+interface DirectionLineProps {
+  id?: string;
+  coordinates: Coordinates[];
+  color?: string;
+  width?: number;
+}
+
+export default function DirectionLine({
+  id,
+  coordinates,
+  color = "red",
+  width = 3,
+}: DirectionLineProps) {
+  if (!id) id = "direction-line";
+
+  return (
+    <ShapeSource
+      id={id}
+      testID="direction-line-source"
+      shape={{
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "LineString", coordinates },
+            properties: {},
+          },
+        ],
+      }}
+    >
+      <LineLayer id={`layer-${id}`} style={{ lineColor: color, lineWidth: width }} />
+    </ShapeSource>
+  );
+}

--- a/app/src/components/map/DirectionLines.tsx
+++ b/app/src/components/map/DirectionLines.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { ShapeSource, LineLayer } from "@rnmapbox/maps";
 import { TRANSPORTATION_COLORS } from "@constants/transportation-color";
-
-interface DirectionLineProps {
-  coordinates: Coordinates[];
-  color: string;
-}
+import DirectionLine from "@components/map/DirectionLine";
 
 interface DirectionLinesProps {
   coordinates: Coordinates[][];
@@ -15,40 +11,13 @@ export default function DirectionLines({ coordinates }: DirectionLinesProps) {
   return (
     <>
       {coordinates.map((coords, index) => (
-        <DirectionLine key={index} coordinates={coords} color={TRANSPORTATION_COLORS[index]} />
+        <DirectionLine
+          key={index}
+          id={`line-${index}`}
+          coordinates={coords}
+          color={TRANSPORTATION_COLORS[index]}
+        />
       ))}
     </>
-  );
-}
-
-function DirectionLine({ coordinates, color }: DirectionLineProps) {
-  const lineId = `directions-line-${JSON.stringify(coordinates)}`;
-
-  return (
-    <ShapeSource
-      id={lineId}
-      testID="directions-line-source"
-      shape={{
-        type: "FeatureCollection",
-        features: [
-          {
-            type: "Feature",
-            geometry: {
-              type: "LineString",
-              coordinates,
-            },
-            properties: {},
-          },
-        ],
-      }}
-    >
-      <LineLayer
-        id={`directions-layer-${lineId}`}
-        style={{
-          lineColor: color,
-          lineWidth: 3,
-        }}
-      />
-    </ShapeSource>
   );
 }

--- a/app/src/components/map/MapShell.tsx
+++ b/app/src/components/map/MapShell.tsx
@@ -30,8 +30,8 @@ export const MapShell = ({
 
   const handleMapLoaded = () => {
     if (cameraRef?.current && fitBounds) {
-      const frame = [50, 150, 50, 100];
-      cameraRef.current.fitBounds(fitBounds[0], fitBounds[1], frame);
+      const padding = [150, 50, 300, 50];
+      cameraRef.current.fitBounds(fitBounds[0], fitBounds[1], padding);
     }
   };
 

--- a/app/src/components/map/MapShell.tsx
+++ b/app/src/components/map/MapShell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Platform } from "react-native";
 import Mapbox, { Images, MapView, Camera, UserLocation, Location } from "@rnmapbox/maps";
-
+import type { Feature, Point } from "geojson";
 import pinIcon from "@assets/pin-purple.png";
 import trafficIcon from "@assets/report-traffic.png";
 import lineIcon from "@assets/report-lines.png";
@@ -19,7 +19,7 @@ interface MapShellProps {
   fitBounds?: Coordinates[];
   handleMapPress?: (feature: MapPressFeature) => void;
   handleUserLocation?: (location: Location) => void;
-  handleRegionChange?: (region: any) => void;
+  handleRegionChange?: (region: Feature<Point, MapBoxRegionPayload>) => void;
   cameraProps?: React.ComponentProps<typeof Camera>;
   userLocationProps?: React.ComponentProps<typeof UserLocation>;
 }

--- a/app/src/components/map/MapShell.tsx
+++ b/app/src/components/map/MapShell.tsx
@@ -20,6 +20,8 @@ interface MapShellProps {
   handleMapPress?: (feature: MapPressFeature) => void;
   handleUserLocation?: (location: Location) => void;
   handleRegionChange?: (region: any) => void;
+  cameraProps?: React.ComponentProps<typeof Camera>;
+  userLocationProps?: React.ComponentProps<typeof UserLocation>;
 }
 
 export const MapShell = ({
@@ -31,6 +33,8 @@ export const MapShell = ({
   handleMapPress,
   handleUserLocation,
   handleRegionChange,
+  cameraProps,
+  userLocationProps,
 }: MapShellProps) => {
   const finalCenter = center ?? [121.05, 14.63]; // Fallback to QC
 
@@ -62,12 +66,14 @@ export const MapShell = ({
         centerCoordinate={finalCenter}
         zoomLevel={zoomLevel ?? 12}
         animationMode={Platform.OS === "android" ? "none" : "easeTo"}
+        {...cameraProps}
       />
       <UserLocation
         visible={true}
         androidRenderMode="normal"
         showsUserHeadingIndicator={true}
         onUpdate={handleUserLocation}
+        {...userLocationProps}
       />
       {children}
       <Images images={markers} />

--- a/app/src/components/map/MapShell.tsx
+++ b/app/src/components/map/MapShell.tsx
@@ -2,7 +2,11 @@ import React from "react";
 import { Platform } from "react-native";
 import Mapbox, { Images, MapView, Camera, UserLocation, Location } from "@rnmapbox/maps";
 
-import pin from "@assets/pin-purple.png";
+import pinIcon from "@assets/pin-purple.png";
+import trafficIcon from "@assets/report-traffic.png";
+import lineIcon from "@assets/report-lines.png";
+import disruptionIcon from "@assets/report-disruption.png";
+
 import { MAPBOX_ACCESS_TOKEN } from "@utils/mapbox-config";
 
 Mapbox.setAccessToken(MAPBOX_ACCESS_TOKEN);
@@ -15,6 +19,7 @@ interface MapShellProps {
   fitBounds?: Coordinates[];
   handleMapPress?: (feature: MapPressFeature) => void;
   handleUserLocation?: (location: Location) => void;
+  handleRegionChange?: (region: any) => void;
 }
 
 export const MapShell = ({
@@ -25,6 +30,7 @@ export const MapShell = ({
   fitBounds,
   handleMapPress,
   handleUserLocation,
+  handleRegionChange,
 }: MapShellProps) => {
   const finalCenter = center ?? [121.05, 14.63]; // Fallback to QC
 
@@ -35,6 +41,13 @@ export const MapShell = ({
     }
   };
 
+  const markers = {
+    pin: pinIcon,
+    Traffic: trafficIcon,
+    Disruption: disruptionIcon,
+    "Long Line": lineIcon,
+  };
+
   return (
     <MapView
       style={{ flex: 1 }}
@@ -42,11 +55,12 @@ export const MapShell = ({
       onPress={handleMapPress}
       projection="mercator"
       onDidFinishLoadingMap={handleMapLoaded}
+      onRegionDidChange={handleRegionChange}
     >
       <Camera
         ref={cameraRef}
         centerCoordinate={finalCenter}
-        zoomLevel={zoomLevel}
+        zoomLevel={zoomLevel ?? 12}
         animationMode={Platform.OS === "android" ? "none" : "easeTo"}
       />
       <UserLocation
@@ -56,7 +70,7 @@ export const MapShell = ({
         onUpdate={handleUserLocation}
       />
       {children}
-      <Images images={{ pin }} />
+      <Images images={markers} />
     </MapView>
   );
 };

--- a/app/src/hooks/use-live-updates.tsx
+++ b/app/src/hooks/use-live-updates.tsx
@@ -1,50 +1,54 @@
 import { useState, useEffect, useRef } from "react";
-import { fetchLiveUpdatesBBox } from "@services/trip-service";
-
-interface LiveUpdate {
-  id: string;
-  type: string;
-  coordinate: Coordinates;
-}
+import { expandBoundingBox } from "@utils/map-utils";
+import { fetchLiveUpdatesBBox, fetchLiveUpdatesLine } from "@services/trip-service";
 
 // This hook fetches live updates based on the camera region.
 // Each time the camera moves, it fetches new live updates.
 // It also sets an interval to fetch live updates for that region.
-export const useLiveUpdates = (region: any, interval: number) => {
+export const useLiveUpdates = (type: "box" | "line", interval: number) => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [coordinates, setUpdateCoords] = useState<Coordinates[] | null>(null);
   const [liveUpdates, setLiveUpdates] = useState<LiveUpdate[]>([]);
 
   useEffect(() => {
     const fetchLiveUpdates = async () => {
-      if (!region) return;
+      if (!coordinates) return;
 
-      // Generate search bounds based on the camera region
-      const bounds = region.properties.visibleBounds;
-      const width = (bounds[1][0] - bounds[0][0]) * 0.5;
-      const height = (bounds[1][1] - bounds[0][1]) * 0.5;
-      const searchBounds = [
-        [bounds[0][0] - width, bounds[0][1] - height],
-        [bounds[1][0] + width, bounds[1][1] + height],
-      ] as [Coordinates, Coordinates];
+      if (type === "box") {
+        // Generate search bounds based on the camera region
+        const searchBounds = expandBoundingBox(coordinates, 0.5);
 
-      // Fetch live updates based on the search bounds
-      const data = await fetchLiveUpdatesBBox(searchBounds);
-      setLiveUpdates(data);
-
-      // Create an interval that continuously fetches live updates
-      intervalRef.current = setInterval(async () => {
+        // Fetch live updates based on the search bounds
         const data = await fetchLiveUpdatesBBox(searchBounds);
         setLiveUpdates(data);
-      }, interval);
+
+        // Create an interval that continuously fetches live updates
+        intervalRef.current = setInterval(async () => {
+          const data = await fetchLiveUpdatesBBox(searchBounds);
+          setLiveUpdates(data);
+        }, interval * 1000);
+      }
+
+      if (type === "line") {
+        // Fetch live updates based on the line coordinates
+        const data = await fetchLiveUpdatesLine(coordinates, interval);
+        setLiveUpdates(data);
+
+        // Create an interval that continuously fetches live updates
+        intervalRef.current = setInterval(async () => {
+          const data = await fetchLiveUpdatesLine(coordinates, interval);
+          setLiveUpdates(data);
+        }, interval * 1000);
+      }
     };
 
     fetchLiveUpdates();
 
-    // Cleanup the interval when the component unmounts or region changes
     return () => {
+      // Cleanup when the component unmounts or coordinate changes
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [region]); // The hook depends on the `region` prop
+  }, [coordinates]);
 
-  return liveUpdates;
+  return { liveUpdates, setUpdateCoords };
 };

--- a/app/src/hooks/use-live-updates.tsx
+++ b/app/src/hooks/use-live-updates.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect, useRef } from "react";
+import { fetchLiveUpdatesBBox } from "@services/trip-service";
+
+interface LiveUpdate {
+  id: string;
+  type: string;
+  coordinate: Coordinates;
+}
+
+// This hook fetches live updates based on the camera region.
+// Each time the camera moves, it fetches new live updates.
+// It also sets an interval to fetch live updates for that region.
+export const useLiveUpdates = (region: any, interval: number) => {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [liveUpdates, setLiveUpdates] = useState<LiveUpdate[]>([]);
+
+  useEffect(() => {
+    const fetchLiveUpdates = async () => {
+      if (!region) return;
+
+      // Generate search bounds based on the camera region
+      const bounds = region.properties.visibleBounds;
+      const width = (bounds[1][0] - bounds[0][0]) * 0.5;
+      const height = (bounds[1][1] - bounds[0][1]) * 0.5;
+      const searchBounds = [
+        [bounds[0][0] - width, bounds[0][1] - height],
+        [bounds[1][0] + width, bounds[1][1] + height],
+      ] as [Coordinates, Coordinates];
+
+      // Fetch live updates based on the search bounds
+      const data = await fetchLiveUpdatesBBox(searchBounds);
+      setLiveUpdates(data);
+
+      // Create an interval that continuously fetches live updates
+      intervalRef.current = setInterval(async () => {
+        const data = await fetchLiveUpdatesBBox(searchBounds);
+        setLiveUpdates(data);
+      }, interval);
+    };
+
+    fetchLiveUpdates();
+
+    // Cleanup the interval when the component unmounts or region changes
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [region]); // The hook depends on the `region` prop
+
+  return liveUpdates;
+};

--- a/app/src/services/trip-service.ts
+++ b/app/src/services/trip-service.ts
@@ -165,7 +165,7 @@ export async function fetchTripData(endpoints: TripEndpoints, radius: number): P
   }
 }
 
-export async function fetchLiveUpdatesBBox(coordinates: [Coordinates, Coordinates]) {
+export async function fetchLiveUpdatesBBox(coordinates: Coordinates[]) {
   try {
     const args = {
       min_lat: coordinates[0][1],

--- a/app/src/services/trip-service.ts
+++ b/app/src/services/trip-service.ts
@@ -11,6 +11,7 @@ import {
   convertKeysToCamelCase,
   convertToPointWKT,
   convertToMultiPointWKT,
+  convertToLineStringWKT,
 } from "@utils/map-utils";
 
 // Inserts a new trip record into the database
@@ -164,14 +165,15 @@ export async function fetchTripData(endpoints: TripEndpoints, radius: number): P
   }
 }
 
-// Fetches nearby live updates based on provided coordinates and radius
-export async function fetchNearbyLiveUpdates(
-  coordinates: Coordinates,
-  radius: number,
-): Promise<LiveUpdate[]> {
+export async function fetchLiveUpdatesBBox(coordinates: [Coordinates, Coordinates]) {
   try {
-    const args = { lat: coordinates[1], lon: coordinates[0], radius };
-    const res = await fetchDataRPC("fetch_nearby_live_updates", args);
+    const args = {
+      min_lat: coordinates[0][1],
+      min_lon: coordinates[0][0],
+      max_lat: coordinates[1][1],
+      max_lon: coordinates[1][0],
+    };
+    const res = await fetchDataRPC("fetch_live_updates_bbox", args);
 
     // Validate the response data
     const result = LiveUpdatesSchema.safeParse(res);
@@ -182,15 +184,10 @@ export async function fetchNearbyLiveUpdates(
   }
 }
 
-export async function fetchLiveUpdatesBBox(coordinates: [Coordinates, Coordinates]) {
+export async function fetchLiveUpdatesLine(line: Coordinates[], distance: number) {
   try {
-    const args = {
-      min_lat: coordinates[0][1],
-      min_lon: coordinates[0][0],
-      max_lat: coordinates[1][1],
-      max_lon: coordinates[1][0],
-    };
-    const res = await fetchDataRPC("fetch_live_updates_bbox", args);
+    const args = { line: convertToLineStringWKT(line), distance };
+    const res = await fetchDataRPC("fetch_live_updates_line", args);
 
     // Validate the response data
     const result = LiveUpdatesSchema.safeParse(res);
@@ -228,3 +225,21 @@ export async function deleteSegments(segmentIds: string[]): Promise<void> {
     throw new Error("Error deleting segments");
   }
 }
+
+// Fetches nearby live updates based on provided coordinates and radius
+// export async function fetchNearbyLiveUpdates(
+//   coordinates: Coordinates,
+//   radius: number,
+// ): Promise<LiveUpdate[]> {
+//   try {
+//     const args = { lat: coordinates[1], lon: coordinates[0], radius };
+//     const res = await fetchDataRPC("fetch_nearby_live_updates", args);
+
+//     // Validate the response data
+//     const result = LiveUpdatesSchema.safeParse(res);
+//     if (!result.success) throw new Error("Invalid Live Update Data");
+//     return result.data;
+//   } catch (error) {
+//     throw new Error("Error fetching live updates");
+//   }
+// }

--- a/app/src/services/trip-service.ts
+++ b/app/src/services/trip-service.ts
@@ -182,6 +182,25 @@ export async function fetchNearbyLiveUpdates(
   }
 }
 
+export async function fetchLiveUpdatesBBox(coordinates: [Coordinates, Coordinates]) {
+  try {
+    const args = {
+      min_lat: coordinates[0][1],
+      min_lon: coordinates[0][0],
+      max_lat: coordinates[1][1],
+      max_lon: coordinates[1][0],
+    };
+    const res = await fetchDataRPC("fetch_live_updates_bbox", args);
+
+    // Validate the response data
+    const result = LiveUpdatesSchema.safeParse(res);
+    if (!result.success) throw new Error("Invalid Live Update Data");
+    return result.data;
+  } catch (error) {
+    throw new Error("Error fetching live updates");
+  }
+}
+
 // Updates the profile record
 export async function updateProfile(profile: Partial<Profile>): Promise<void> {
   try {

--- a/app/src/types/location-types.d.ts
+++ b/app/src/types/location-types.d.ts
@@ -65,6 +65,17 @@ declare global {
     [key: string]: any;
   };
 
+  export type MapBoxRegionPayload = {
+    zoomLevel: number;
+    heading: number;
+    animated: boolean;
+    isUserInteraction: boolean;
+    visibleBounds: GeoJSON.Position[];
+    pitch: number;
+  };
+
+  export type MapViewRegionChange = Feature<Point, MapBoxRegionPayload>;
+
   export type NearestPoint = Feature<Point, NearestPointProperties>;
 }
 

--- a/app/src/types/route-types.d.ts
+++ b/app/src/types/route-types.d.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 import type { FeatureCollection, LineString } from "geojson";
 import { Timestamp } from "react-native-reanimated/lib/typescript/commonTypes";
 
+import type { RouteInputSchema } from "./route-input-schema";
+
 import type {
   TransportationModeSchema,
   TransitJournalStatusSchema,
@@ -44,8 +46,7 @@ declare global {
     contributor_id: string;
   }
 
-  // ==================== V2 ====================
-  // types are inferred from the zod schema to reduce redundancy
+  // ==================== DATABSE ====================
 
   export type TransportationMode = z.infer<typeof TransportationModeSchema>;
   export type TransitJournalStatus = z.infer<typeof TransitJournalStatusSchema>;
@@ -81,4 +82,8 @@ declare global {
   >;
 
   export type Profile = z.infer<typeof ProfileSchema>;
+
+  // ==================== INPUT ====================
+
+  export type RouteInput = z.infer<typeof RouteInputSchema>;
 }

--- a/app/src/types/schema.ts
+++ b/app/src/types/schema.ts
@@ -176,3 +176,15 @@ export const ProfileSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
 });
+
+// ================== INPUT SCHEMA ==================
+
+export const RouteInputSchema = z.object({
+  segmentName: z.string().min(1, "Route name is required").min(3, "Route name is too short"),
+  segmentMode: TransportationModeSchema,
+  cost: z.number(),
+  landmark: z.string().nullable(),
+  instruction: z.string().nullable(),
+  waypoints: z.array(CoordinatesSchema).min(2, "Please generate the route"),
+  navigationSteps: z.array(NavigationStepsSchema),
+});

--- a/app/src/utils/map-utils.ts
+++ b/app/src/utils/map-utils.ts
@@ -91,3 +91,14 @@ export function getNearestStep(
   });
   return steps[stepIndex];
 }
+
+export function expandBoundingBox(box: Coordinates[], size: number): Coordinates[] {
+  const [min, max] = box;
+  const width = (max[0] - min[0]) * size;
+  const height = (max[1] - min[1]) * size;
+
+  return [
+    [min[0] - width, min[1] - height],
+    [max[0] + width, max[1] + height],
+  ];
+}

--- a/app/src/utils/map-utils.ts
+++ b/app/src/utils/map-utils.ts
@@ -42,6 +42,14 @@ export function convertToMultiPointWKT(points: Coordinates[]): string | null {
   return `SRID=4326;MULTIPOINT(${pointStrings})`;
 }
 
+export function convertToLineStringWKT(points: Coordinates[]): string | null {
+  if (points.length === 0) {
+    return null;
+  }
+  const pointStrings = points.map(([lng, lat]) => `${lng} ${lat}`).join(", ");
+  return `SRID=4326;LINESTRING(${pointStrings})`;
+}
+
 export function getNearestSegment(
   userLocation: Coordinates,
   segments: Segment[],

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -13,7 +13,8 @@
       "@utils/*": ["utils/*"],
       "@api/*": ["api/*"],
       "@app/*": ["app/*"],
-      "@test-utils/*": ["__test-utils__/*"],
+      "@schemas": ["types/schema"],
+      "@test-utils/*": ["__test-utils__/*"]
     }
   },
   "include": [


### PR DESCRIPTION
**Enhancements:**

**Tab Index**
- Added a live update hook to the home page, utilizing the camera’s bounding box to fetch relevant data.
- Renders live updates based on the camera regions, added callback to fetch new data every 30 seconds.

**Transit Journal**
- Integrated live updates into the transit journal, using the trip segment line as a reference to fetch real-time data.
- Should only render active segment, will work on this in the future.

**Supabase**
- added `fetch_live_updates_line`
- added `fetch_live_updates_bbox`
- removed `fetch_nearby_live_updates`

**Future Work:**

- Live update icons for better UI.
- Perform code cleanup for transit journal.

> [!IMPORTANT]
> realtime live update fetch cleanup is still buggy

Build on top of #46